### PR TITLE
Make some attributes optional

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -20,6 +20,8 @@ use crate::{config::Config, models::Alert};
 /// - **Reason:** `…`                       ← only shown when present
 /// - **Pod:** `…`
 /// - **Container:** `…`
+/// - **Start time:** `…`              ← UTC ISO 8601
+/// - **End time:** `…`                ← only shown when present, UTC ISO 8601
 ///
 /// 📊 [Prometheus](…)  · 📖 [Runbook](…) ← Runbook only when present
 /// ```
@@ -118,10 +120,22 @@ pub fn to_markdown(alert: &Alert, config: &Config) -> String {
         writeln!(out, "- **Correlated alerts:** [{}]({})", parent_name, url).unwrap();
     }
 
+    if let Some(ts) = parse_datetime_to_iso(&alert.started_at) {
+        writeln!(out, "- **Start time:** {}", ts).unwrap();
+    }
+    if let Some(ref ends_at) = alert.ends_at {
+        if let Some(ts) = parse_datetime_to_iso(ends_at) {
+            writeln!(out, "- **End time:** {}", ts).unwrap();
+        }
+    }
+
     // ── Footer links ──────────────────────────────────────────────────────────
     writeln!(out).unwrap();
 
-    let mut footer: Vec<String> = vec![format!("📊 [Prometheus]({})", alert.generator_url)];
+    let mut footer: Vec<String> = Vec::new();
+    if let Some(ref generator_url) = alert.generator_url {
+        footer.push(format!("📊 [Prometheus]({})", generator_url));
+    }
     if let Some(runbook_url) = &alert.annotations.runbook_url {
         footer.push(format!("📖 [Runbook]({})", runbook_url));
     }
@@ -271,8 +285,8 @@ mod tests {
             firing_counter: 3,
             fingerprint: "abc123def456".into(),
             assignee: None,
-            ends_at: "2026-01-01T02:00:00Z".into(),
-            generator_url: "http://prometheus/graph".into(),
+            ends_at: Some("2026-01-01T02:00:00Z".into()),
+            generator_url: Some("http://prometheus/graph".into()),
             description: None,
             rca_summary: None,
             correlated_parent_alert: None,

--- a/src/models.rs
+++ b/src/models.rs
@@ -51,9 +51,9 @@ pub struct Alert {
     /// `null` when unassigned; the key must be present in the payload.
     pub assignee: Option<String>,
     /// Raw timestamp string from `endsAt`.
-    pub ends_at: String,
+    pub ends_at: Option<String>,
     /// Prometheus generator URL (`generatorURL`).
-    pub generator_url: String,
+    pub generator_url: Option<String>,
 
     // ── Optional ─────────────────────────────────────────────────────────────
     pub description: Option<String>,
@@ -145,8 +145,8 @@ impl Alert {
         let started_at = req_str(v, "/startedAt", &mut missing);
         let last_received = req_str(v, "/lastReceived", &mut missing);
         let fingerprint = req_str(v, "/fingerprint", &mut missing);
-        let ends_at = req_str(v, "/endsAt", &mut missing);
-        let generator_url = req_str(v, "/generatorURL", &mut missing);
+        let ends_at = opt_str(v, "/endsAt");
+        let generator_url = opt_str(v, "/generatorURL");
         let firing_counter = req_u64(v, "/firingCounter", &mut missing);
 
         // `assignee` must be present as a key but its value may be null.
@@ -168,8 +168,8 @@ impl Alert {
             firing_counter: firing_counter.unwrap(),
             fingerprint: fingerprint.unwrap(),
             assignee,
-            ends_at: ends_at.unwrap(),
-            generator_url: generator_url.unwrap(),
+            ends_at,
+            generator_url,
             description: opt_str(v, "/description"),
             rca_summary: opt_str(v, "/rca_summary"),
             correlated_parent_alert: opt_str(v, "/correlated_parent_alert"),


### PR DESCRIPTION
- Make ends_at optional
- Make generator_url optional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alert start and end times now display in UTC ISO 8601 format for improved consistency

* **Bug Fixes**
  * Prometheus links now display conditionally when data is available, preventing missing link errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->