### PR TITLE
Use default firing time

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -113,7 +113,7 @@ pub fn to_markdown(alert: &Alert, config: &Config) -> String {
         writeln!(out, "- **Correlated alerts:** [{}]({})", parent_name, url).unwrap();
     }
 
-    if let Some(ts) = parse_datetime_to_iso(&alert.started_at) {
+    if let Some(ts) = parse_datetime_to_iso(&alert.effective_started_at()) {
         writeln!(out, "- **Start time:** {}", ts).unwrap();
     }
     if let Some(ref ends_at) = alert.ends_at {
@@ -236,7 +236,7 @@ fn build_graylog_url(alert: &Alert, config: &Config) -> Option<String> {
     let namespace = alert.namespace.as_deref()?;
     let app_name = alert.labels.app_name.as_deref()?;
 
-    let start_iso = parse_datetime_to_iso(&alert.started_at)?;
+    let start_iso = parse_datetime_to_iso(&alert.effective_started_at())?;
     let end_iso = Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
 
     Some(format!(
@@ -372,7 +372,8 @@ mod tests {
             name: "TestAlert".into(),
             status: status.into(),
             severity: severity.into(),
-            started_at: "2026-01-01 00:00:00".into(),
+            started_at: Some("2026-01-01 00:00:00".into()),
+            firing_start_time: None,
             last_received: "2026-01-01T01:00:00Z".into(),
             firing_counter: 3,
             fingerprint: "abc123def456".into(),

--- a/src/models.rs
+++ b/src/models.rs
@@ -12,7 +12,7 @@ pub struct AlertLabels {
     pub pod: Option<String>,
     pub reason: Option<String>,
     pub container: Option<String>,
-    /// `labels.label_app_kubernetes_io_name`
+    /// `labels.app_kubernetes_io_name`
     pub app_name: Option<String>,
 }
 
@@ -41,8 +41,10 @@ pub struct Alert {
     pub name: String,
     pub status: String,
     pub severity: String,
-    /// Raw timestamp string from `startedAt`.
-    pub started_at: String,
+    /// Raw timestamp string from `startedAt`. Optional; falls back to `firing_start_time` or system time.
+    pub started_at: Option<String>,
+    /// Raw timestamp string from `firingStartTime` in the payload.
+    pub firing_start_time: Option<String>,
     /// Raw timestamp string from `lastReceived`.
     pub last_received: String,
     /// Number of times the alert has fired (`firingCounter`).
@@ -142,7 +144,8 @@ impl Alert {
         let name = req_str(v, "/name", &mut missing);
         let status = req_str(v, "/status", &mut missing);
         let severity = req_str(v, "/severity", &mut missing);
-        let started_at = req_str(v, "/startedAt", &mut missing);
+        let started_at = opt_str(v, "/startedAt");
+        let firing_start_time = opt_str(v, "/firingStartTime");
         let last_received = req_str(v, "/lastReceived", &mut missing);
         let fingerprint = req_str(v, "/fingerprint", &mut missing);
         let ends_at = opt_str(v, "/endsAt");
@@ -163,7 +166,8 @@ impl Alert {
             name: name.unwrap(),
             status: status.unwrap(),
             severity: severity.unwrap(),
-            started_at: started_at.unwrap(),
+            started_at,
+            firing_start_time,
             last_received: last_received.unwrap(),
             firing_counter: firing_counter.unwrap(),
             fingerprint: fingerprint.unwrap(),
@@ -179,13 +183,24 @@ impl Alert {
                 pod: opt_str(v, "/labels/pod"),
                 reason: opt_str(v, "/labels/reason"),
                 container: opt_str(v, "/labels/container"),
-                app_name: opt_str(v, "/labels/label_app_kubernetes_io_name"),
+                app_name: opt_str(v, "/labels/app_kubernetes_io_name"),
             },
             annotations: AlertAnnotations {
                 summary: opt_str(v, "/annotations/summary"),
                 runbook_url: opt_str(v, "/annotations/runbook_url"),
             },
         })
+    }
+
+    /// Resolves the effective start time using a fallback chain:
+    /// 1. `started_at` from the payload
+    /// 2. `firing_start_time` from the payload
+    /// 3. current system time (UTC)
+    pub fn effective_started_at(&self) -> String {
+        self.started_at
+            .clone()
+            .or_else(|| self.firing_start_time.clone())
+            .unwrap_or_else(|| Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
     }
 }
 

--- a/test/KubeContainerWaiting-01.json
+++ b/test/KubeContainerWaiting-01.json
@@ -27,7 +27,7 @@
   "labels": {
     "alertname": "KubeContainerWaiting",
     "container": "crash-test",
-    "label_app_kubernetes_io_name": "crash-test-app",
+    "app_kubernetes_io_name": "crash-test-app",
     "namespace": "monitoring",
     "pod": "crash-test",
     "prometheus": "monitoring/kube-prometheus-stack",
@@ -91,7 +91,7 @@
   "payload": {
     "startsAt": "2026-05-26T16:31:25.265Z",
     "endsAt": "2026-05-26T16:36:25.265Z",
-    "generatorURL": "http://prometheus.staging.hoprnet.link/graph?g0.expr=%28max+by+%28namespace%2C+pod%2C+container%2C+reason%29+%28kube_pod_container_status_waiting_reason%7Bjob%3D%22kube-state-metrics%22%2Cnamespace%3D~%22.%2A%22%7D+%3E+0%29%29+%2A+on+%28namespace%2C+pod%29+group_left+%28label_app_kubernetes_io_name%29+kube_pod_labels&g0.tab=1"
+    "generatorURL": "http://prometheus.staging.hoprnet.link/graph?g0.expr=%28max+by+%28namespace%2C+pod%2C+container%2C+reason%29+%28kube_pod_container_status_waiting_reason%7Bjob%3D%22kube-state-metrics%22%2Cnamespace%3D~%22.%2A%22%7D+%3E+0%29%29+%2A+on+%28namespace%2C+pod%29+group_left+%28app_kubernetes_io_name%29+kube_pod_labels&g0.tab=1"
   },
   "severity_emoji": "⚠️",
   "correlated_alert": "KubePodCrashLooping",
@@ -106,11 +106,11 @@
     "runbook_url": "https://github.com/hoprnet/gitops/blob/master/operations/runbooks/KubeContainerWaiting.md",
     "summary": "Application crash-test-app has a container that cannot start."
   },
-  "generatorURL": "http://prometheus.staging.hoprnet.link/graph?g0.expr=%28max+by+%28namespace%2C+pod%2C+container%2C+reason%29+%28kube_pod_container_status_waiting_reason%7Bjob%3D%22kube-state-metrics%22%2Cnamespace%3D~%22.%2A%22%7D+%3E+0%29%29+%2A+on+%28namespace%2C+pod%29+group_left+%28label_app_kubernetes_io_name%29+kube_pod_labels&g0.tab=1",
+  "generatorURL": "http://prometheus.staging.hoprnet.link/graph?g0.expr=%28max+by+%28namespace%2C+pod%2C+container%2C+reason%29+%28kube_pod_container_status_waiting_reason%7Bjob%3D%22kube-state-metrics%22%2Cnamespace%3D~%22.%2A%22%7D+%3E+0%29%29+%2A+on+%28namespace%2C+pod%29+group_left+%28app_kubernetes_io_name%29+kube_pod_labels&g0.tab=1",
   "container": "crash-test",
   "correlated_fingerprint": "b58e9384887fe382",
   "pod": "crash-test",
-  "label_app_kubernetes_io_name": "crash-test-app",
+  "app_kubernetes_io_name": "crash-test-app",
   "value": "",
   "correlated_alert_severity": "warning"
 }

--- a/test/KubePodCrashLooping-01.json
+++ b/test/KubePodCrashLooping-01.json
@@ -27,7 +27,7 @@
   "labels": {
     "alertname": "KubePodCrashLooping",
     "container": "crash-test",
-    "label_app_kubernetes_io_name": "crash-test-app",
+    "app_kubernetes_io_name": "crash-test-app",
     "namespace": "monitoring",
     "pod": "crash-test",
     "prometheus": "monitoring/kube-prometheus-stack",
@@ -91,7 +91,7 @@
   "payload": {
     "startsAt": "2026-05-26T09:06:25.265Z",
     "endsAt": "2026-05-26T16:41:55.265Z",
-    "generatorURL": "http://prometheus.staging.hoprnet.link/graph?g0.expr=%28max+by+%28namespace%2C+pod%2C+container%2C+reason%29+%28max_over_time%28kube_pod_container_status_waiting_reason%7Bjob%3D%22kube-state-metrics%22%2Cnamespace%3D~%22.%2A%22%2Creason%3D%22CrashLoopBackOff%22%7D%5B5m%5D%29+%3E%3D+1%29%29+%2A+on+%28namespace%2C+pod%29+group_left+%28label_app_kubernetes_io_name%29+kube_pod_labels&g0.tab=1"
+    "generatorURL": "http://prometheus.staging.hoprnet.link/graph?g0.expr=%28max+by+%28namespace%2C+pod%2C+container%2C+reason%29+%28max_over_time%28kube_pod_container_status_waiting_reason%7Bjob%3D%22kube-state-metrics%22%2Cnamespace%3D~%22.%2A%22%2Creason%3D%22CrashLoopBackOff%22%7D%5B5m%5D%29+%3E%3D+1%29%29+%2A+on+%28namespace%2C+pod%29+group_left+%28app_kubernetes_io_name%29+kube_pod_labels&g0.tab=1"
   },
   "severity_emoji": "⚠️",
   "alertname": "KubePodCrashLooping",
@@ -106,9 +106,9 @@
     "runbook_url": "https://github.com/hoprnet/gitops/blob/master/operations/runbooks/KubePodCrashLooping.md",
     "summary": "Application crash-test-app is repeatedly crashing and cannot start."
   },
-  "generatorURL": "http://prometheus.staging.hoprnet.link/graph?g0.expr=%28max+by+%28namespace%2C+pod%2C+container%2C+reason%29+%28max_over_time%28kube_pod_container_status_waiting_reason%7Bjob%3D%22kube-state-metrics%22%2Cnamespace%3D~%22.%2A%22%2Creason%3D%22CrashLoopBackOff%22%7D%5B5m%5D%29+%3E%3D+1%29%29+%2A+on+%28namespace%2C+pod%29+group_left+%28label_app_kubernetes_io_name%29+kube_pod_labels&g0.tab=1",
+  "generatorURL": "http://prometheus.staging.hoprnet.link/graph?g0.expr=%28max+by+%28namespace%2C+pod%2C+container%2C+reason%29+%28max_over_time%28kube_pod_container_status_waiting_reason%7Bjob%3D%22kube-state-metrics%22%2Cnamespace%3D~%22.%2A%22%2Creason%3D%22CrashLoopBackOff%22%7D%5B5m%5D%29+%3E%3D+1%29%29+%2A+on+%28namespace%2C+pod%29+group_left+%28app_kubernetes_io_name%29+kube_pod_labels&g0.tab=1",
   "pod": "crash-test",
-  "label_app_kubernetes_io_name": "crash-test-app",
+  "app_kubernetes_io_name": "crash-test-app",
   "value": "",
   "container": "crash-test"
 }

--- a/test/KubePodCrashLooping-02.json
+++ b/test/KubePodCrashLooping-02.json
@@ -27,7 +27,7 @@
   "labels": {
     "alertname": "KubePodCrashLooping",
     "container": "crash-test",
-    "label_app_kubernetes_io_name": "crash-test-app",
+    "app_kubernetes_io_name": "crash-test-app",
     "namespace": "monitoring",
     "pod": "crash-test",
     "prometheus": "monitoring/kube-prometheus-stack",
@@ -91,7 +91,7 @@
   "payload": {
     "startsAt": "2026-05-26T09:06:25.265Z",
     "endsAt": "2026-05-26T16:41:55.265Z",
-    "generatorURL": "http://prometheus.staging.hoprnet.link/graph?g0.expr=%28max+by+%28namespace%2C+pod%2C+container%2C+reason%29+%28max_over_time%28kube_pod_container_status_waiting_reason%7Bjob%3D%22kube-state-metrics%22%2Cnamespace%3D~%22.%2A%22%2Creason%3D%22CrashLoopBackOff%22%7D%5B5m%5D%29+%3E%3D+1%29%29+%2A+on+%28namespace%2C+pod%29+group_left+%28label_app_kubernetes_io_name%29+kube_pod_labels&g0.tab=1"
+    "generatorURL": "http://prometheus.staging.hoprnet.link/graph?g0.expr=%28max+by+%28namespace%2C+pod%2C+container%2C+reason%29+%28max_over_time%28kube_pod_container_status_waiting_reason%7Bjob%3D%22kube-state-metrics%22%2Cnamespace%3D~%22.%2A%22%2Creason%3D%22CrashLoopBackOff%22%7D%5B5m%5D%29+%3E%3D+1%29%29+%2A+on+%28namespace%2C+pod%29+group_left+%28app_kubernetes_io_name%29+kube_pod_labels&g0.tab=1"
   },
   "severity_emoji": "⚠️",
   "alertname": "KubePodCrashLooping",
@@ -106,9 +106,9 @@
     "runbook_url": "https://github.com/hoprnet/gitops/blob/master/operations/runbooks/KubePodCrashLooping.md",
     "summary": "Application crash-test-app is repeatedly crashing and cannot start."
   },
-  "generatorURL": "http://prometheus.staging.hoprnet.link/graph?g0.expr=%28max+by+%28namespace%2C+pod%2C+container%2C+reason%29+%28max_over_time%28kube_pod_container_status_waiting_reason%7Bjob%3D%22kube-state-metrics%22%2Cnamespace%3D~%22.%2A%22%2Creason%3D%22CrashLoopBackOff%22%7D%5B5m%5D%29+%3E%3D+1%29%29+%2A+on+%28namespace%2C+pod%29+group_left+%28label_app_kubernetes_io_name%29+kube_pod_labels&g0.tab=1",
+  "generatorURL": "http://prometheus.staging.hoprnet.link/graph?g0.expr=%28max+by+%28namespace%2C+pod%2C+container%2C+reason%29+%28max_over_time%28kube_pod_container_status_waiting_reason%7Bjob%3D%22kube-state-metrics%22%2Cnamespace%3D~%22.%2A%22%2Creason%3D%22CrashLoopBackOff%22%7D%5B5m%5D%29+%3E%3D+1%29%29+%2A+on+%28namespace%2C+pod%29+group_left+%28app_kubernetes_io_name%29+kube_pod_labels&g0.tab=1",
   "pod": "crash-test",
-  "label_app_kubernetes_io_name": "crash-test-app",
+  "app_kubernetes_io_name": "crash-test-app",
   "value": "",
   "container": "crash-test"
 }


### PR DESCRIPTION
Adds a default value to startedAt of the rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alert start times are now determined using a fallback logic chain, improving timestamp accuracy when multiple time fields are available.
  * Graylog query time ranges are now aligned with alert timestamps for consistency.
  * Kubernetes label references have been corrected for improved alert identification and correlation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->